### PR TITLE
Add basic support for CC and BCC

### DIFF
--- a/lib/sendwithus_ruby_action_mailer/mail_params.rb
+++ b/lib/sendwithus_ruby_action_mailer/mail_params.rb
@@ -8,6 +8,8 @@ module SendWithUsMailer
       @email_data = {}
       @to = {}
       @from = {}
+      @cc = []
+      @bcc = []
     end
 
     def assign(key, value) #:nodoc:
@@ -29,6 +31,10 @@ module SendWithUsMailer
           @from.merge!(address: value)
         when :reply_to
           @from.merge!(reply_to: value)
+        when :cc
+          @cc.concat(value)
+        when :bcc
+          @bcc.concat(value)
         end
       end
     end
@@ -40,7 +46,7 @@ module SendWithUsMailer
     # In particular, the +api_key+ must be set (following the guidelines in the
     # +send_with_us+ documentation).
     def deliver
-      SendWithUs::Api.new.send_with(@email_id, @to, @email_data, @from)
+      SendWithUs::Api.new.send_with(@email_id, @to, @email_data, @from, @cc, @bcc)
     end
   end
 end


### PR DESCRIPTION
This may not be how you want to implement it, but I added some basic support for CC and BCC, since the main SendWithUs gem supports them and this one currently doesn't. (And I need them.)

The way I've done it, the API is a bit fiddly, so you may have a better idea to handle the array of names and addresses. This way you need to pass something like:

```
:bcc => [{:address => "name@example.com"},{:address => "name2@example.com"}]
```
