### PR TITLE
Add basic support for adding attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ class Notifier < SendWithUsMailer::Base
         mail(
             email_id: 'ID-CODE-FROM-SEND-WITH-US', 
             recipient_address: recipient.email,
-            bcc: [{:address => "name@example.com"},{:address => "name2@example.com"}])
+            bcc: [{:address => "name@example.com"},{:address => "name2@example.com"}]),
+            files: ["/path/to/file"]
     end
 end
 `````

--- a/lib/sendwithus_ruby_action_mailer/mail_params.rb
+++ b/lib/sendwithus_ruby_action_mailer/mail_params.rb
@@ -10,6 +10,7 @@ module SendWithUsMailer
       @from = {}
       @cc = []
       @bcc = []
+      @files = []
     end
 
     def assign(key, value) #:nodoc:
@@ -35,6 +36,8 @@ module SendWithUsMailer
           @cc.concat(value)
         when :bcc
           @bcc.concat(value)
+        when :files
+          @files.concat(value)
         end
       end
     end
@@ -46,7 +49,7 @@ module SendWithUsMailer
     # In particular, the +api_key+ must be set (following the guidelines in the
     # +send_with_us+ documentation).
     def deliver
-      SendWithUs::Api.new.send_with(@email_id, @to, @email_data, @from, @cc, @bcc)
+      SendWithUs::Api.new.send_with(@email_id, @to, @email_data, @from, @cc, @bcc, @files)
     end
   end
 end


### PR DESCRIPTION
I wanted to offer the same interface as ActionMailer for this (e.g. attachments["file.pdf"] = ...), but this was frankly easier and fits better with the SendWithUs base Ruby gem.