### PR TITLE
Adding implementation of `respond_to?` for easier mocking/better API

### DIFF
--- a/lib/sendwithus_ruby_action_mailer/base.rb
+++ b/lib/sendwithus_ruby_action_mailer/base.rb
@@ -77,6 +77,11 @@ module SendWithUsMailer
           super
         end
       end
+
+      # Add our mailer_methods to the set of methods the mailer responds to.
+      def respond_to?(method_name, include_all = false)
+        mailer_methods.include?(method_name.to_sym) || super
+      end
     end
 
     #----------------------- Instance methods ----------------------------


### PR DESCRIPTION
Hello.

I think it's customary when implementing `method_missing` to also implement `respond_to?`, so that the method logic that's happening in `method_missing` is reflected in the public API of the class.

This, for example, makes mocking with RSpec much easier, since rspec-mocks checks the object to be sure it implements a method you're stubbing before you're allowed to stub it.

Thanks!
