### PR TITLE
add a mininum version of send_with_us gem due to parameter list change

### DIFF
--- a/sendwithus_ruby_action_mailer.gemspec
+++ b/sendwithus_ruby_action_mailer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'send_with_us'
+  gem.add_runtime_dependency 'send_with_us', '>= 1.2.1'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest-colorize'
   gem.add_development_dependency 'mocha'


### PR DESCRIPTION
- this version of the send_with_us_action_mailer makes a call to the send_with_us gem using an interface that only shows up on version 1.2.1 and higher of that gem