### PR TITLE
Use `send_email` method instead of deprecated `send_with`

### DIFF
--- a/lib/sendwithus_ruby_action_mailer/mail_params.rb
+++ b/lib/sendwithus_ruby_action_mailer/mail_params.rb
@@ -49,7 +49,17 @@ module SendWithUsMailer
     # In particular, the +api_key+ must be set (following the guidelines in the
     # +send_with_us+ documentation).
     def deliver
-      SendWithUs::Api.new.send_with(@email_id, @to, @email_data, @from, @cc, @bcc, [], "", @version_name)
+      SendWithUs::Api.new.send_email(
+        @email_id,
+        @to,
+        data: @email_data,
+        from: @from,
+        cc: @cc,
+        bcc: @bcc,
+        files: [],
+        esp_account: "",
+        version_name: @version_name
+      )
     end
   end
 end

--- a/sendwithus_ruby_action_mailer.gemspec
+++ b/sendwithus_ruby_action_mailer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'send_with_us'
+  gem.add_runtime_dependency 'send_with_us', '>= 1.9.0'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest-colorize'
   gem.add_development_dependency 'mocha'

--- a/test/lib/sendwithus_ruby_action_mailer/mail_params_test.rb
+++ b/test/lib/sendwithus_ruby_action_mailer/mail_params_test.rb
@@ -58,7 +58,7 @@ describe SendWithUsMailer::MailParams do
     end
 
     it "calls the send_with_us gem" do
-      SendWithUs::Api.any_instance.expects(:send_with)
+      SendWithUs::Api.any_instance.expects(:send_email)
       subject.deliver
     end
   end


### PR DESCRIPTION
P.S.
It would be helpful if you create git tag like `v1.1.1` for each version (from next release). Also, `send_with_as` gem.