### PR TITLE
Sidekiq instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ end
 
 ## Using Sidekiq
 
-Because SendWithUsMailer is not a subclass of ActionMailer (`SendWithUsMailer.is_a? ActionMailer` returns `false`), [Sidekiq's delayed ActionMailer extension](https://github.com/mperham/sidekiq/wiki/Delayed-extensions) will not automatically be included in the SendWithUsMailer, meaning that `YourMailer.delay.your_email` will not work without additional configuration. You can include Sidekiq's delayed ActionMailer in the SendWithUsMailer by putting the following line in config/initializers/send_with_us.rb along with your API config:
+Because SendWithUsMailer is not a subclass of ActionMailer (`SendWithUsMailer.is_a? ActionMailer` returns `false`), [Sidekiq's delayed ActionMailer extension](https://github.com/mperham/sidekiq/wiki/Delayed-extensions) will not automatically be included in the SendWithUsMailer, meaning that `YourMailer.delay.your_email` will not work without additional configuration. You can include Sidekiq's delayed ActionMailer in the SendWithUsMailer by putting the following line in `config/initializers/send_with_us.rb` along with your API config:
 
 `````Ruby
 ::SendWithUsMailer::Base.extend(Sidekiq::Extensions::ActionMailer)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ end
 
 ## Using Sidekiq
 
-Because SendWithUsMailer is not a subclass of ActionMailer (`SendWithUsMailer.is_a? ActionMailer == false`), [Sidekiq's delayed ActionMailer extension](https://github.com/mperham/sidekiq/wiki/Delayed-extensions) will not automatically be included in the SendWithUsMailer, meaning that `YourMailer.delay.your_email` will not work without additional configuration. You can include Sidekiq's delayed ActionMailer in the SendWithUsMailer by putting the following line in config/initializers/send_with_us.rb along with your API config:
+Because SendWithUsMailer is not a subclass of ActionMailer (`SendWithUsMailer.is_a? ActionMailer` returns `false`), [Sidekiq's delayed ActionMailer extension](https://github.com/mperham/sidekiq/wiki/Delayed-extensions) will not automatically be included in the SendWithUsMailer, meaning that `YourMailer.delay.your_email` will not work without additional configuration. You can include Sidekiq's delayed ActionMailer in the SendWithUsMailer by putting the following line in config/initializers/send_with_us.rb along with your API config:
 
 `````Ruby
 ::SendWithUsMailer::Base.extend(Sidekiq::Extensions::ActionMailer)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ class Notifier < SendWithUsMailer::Base
 end
 `````
 
+## Using Sidekiq
+
+Because SendWithUsMailer is not a subclass of ActionMailer (`SendWithUsMailer.is_a? ActionMailer == false`), [Sidekiq's delayed ActionMailer extension](https://github.com/mperham/sidekiq/wiki/Delayed-extensions) will not automatically be included in the SendWithUsMailer, meaning that `YourMailer.delay.your_email` will not work without additional configuration. You can include Sidekiq's delayed ActionMailer in the SendWithUsMailer by putting the following line in config/initializers/send_with_us.rb along with your API config:
+
+`````Ruby
+::SendWithUsMailer::Base.extend(Sidekiq::Extensions::ActionMailer)
+`````
+
+That will cause Sidekiq to actually deliver the emails for jobs it processes offline. Relevant code in [Sidekiq::Extensions::ActionMailer](https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/extensions/action_mailer.rb) and [SendWithUsMailer::Base](https://github.com/sendwithus/sendwithus_ruby_action_mailer/blob/master/lib/sendwithus_ruby_action_mailer/base.rb) should help explain why this is necessary.
+
 ## Contributing
 
 1. Fork it


### PR DESCRIPTION
...ot sending emails as expected and failing silently.

Also, I think this problem is exacerbated by the implementation of `SendWithUsMailer::Base#method_missing`. The Sidekiq jobs were being successfully placed on the queue and successfully being processed without an error message, but emails were still not being sent. When Sidekiq was calling MyMailer.deliver, it did not fail. I would expect a call to MyMailer.deliver to fail if the Sidekiq ActionMailer extension was not findable. I would expect the job to fail with a `NoMethodError`. The implementation of `SendWithUsMailer::Base#method_missing` seems too broad and creates a silent failures when expected methods are not found. You should probably really only overwrite handling for known methods vs. all methods.