### PR TITLE
Inheriting from AbstractController::Base

### DIFF
--- a/lib/sendwithus_ruby_action_mailer/base.rb
+++ b/lib/sendwithus_ruby_action_mailer/base.rb
@@ -1,3 +1,6 @@
+require "action_pack"
+require "abstract_controller"
+
 module SendWithUsMailer
   # Mailer models inherit from <tt>SendWithUsMailer::Base</tt>. A mailer model defines methods
   # used to generate an email message. In these methods, you can assign variables to be sent to
@@ -41,7 +44,8 @@ module SendWithUsMailer
   #   class Notifier < SendWithUsMailer::Base
   #     default from: 'system@example.com'
   #   end
-  class Base
+  class Base < AbstractController::Base
+    abstract!
 
     #---------------------- Singleton methods ----------------------------
     class << self

--- a/sendwithus_ruby_action_mailer.gemspec
+++ b/sendwithus_ruby_action_mailer.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_runtime_dependency 'send_with_us', '>= 1.9.0'
+  gem.add_development_dependency 'actionpack'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest-colorize'
   gem.add_development_dependency 'mocha'


### PR DESCRIPTION
Since this is intended to mimic ActionMailer it makes sense to inherit from AbstractController so other Rails modules can be used as they would be in ActionMailer, e.g. `render_to_string` if part of a template needs to be dynamic.