### PR TITLE
Fork that adds #deliver_now and #deliver_later support to the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ mail.deliver                    # sends the email
 You never instantiate your mailer class. Rather, you just call the method you defined
 on the class itself.
 
+### Sending mail asynchronously with ActiveJob
+
+`````Ruby
+Notifier.welcome(nick).deliver_later # sends the email asynchronously
+
+mail = Notifier.welcome(david)  # => a SendWithUsMailer::MailParams object
+mail.deliver_later              # sends the email asynchronously
+`````
+
+You never instantiate your mailer class. Rather, you just call the method you defined
+on the class itself.
 
 ### Conditional Delivery
 

--- a/lib/sendwithus_ruby_action_mailer.rb
+++ b/lib/sendwithus_ruby_action_mailer.rb
@@ -1,3 +1,4 @@
 require "sendwithus_ruby_action_mailer/version"
 require "sendwithus_ruby_action_mailer/base"
 require "sendwithus_ruby_action_mailer/mail_params"
+require "sendwithus_ruby_action_mailer/jobs/mail_job"

--- a/lib/sendwithus_ruby_action_mailer/jobs/mail_job.rb
+++ b/lib/sendwithus_ruby_action_mailer/jobs/mail_job.rb
@@ -1,0 +1,15 @@
+require "active_job"
+
+module SendWithUsMailer
+  module Jobs
+    # The <tt>SendWithUsMailer::Jobs::MailJob</tt> class is used when you
+    # want to send transactional emails outside of the request-response cycle.
+    class MailJob < ActiveJob::Base
+      queue_as :mailers
+
+      def perform(email_id, to, options)
+        SendWithUs::Api.new.send_email(email_id, to, options)
+      end
+    end
+  end
+end

--- a/lib/sendwithus_ruby_action_mailer/mail_params.rb
+++ b/lib/sendwithus_ruby_action_mailer/mail_params.rb
@@ -79,5 +79,30 @@ module SendWithUsMailer
         tags: @tags
       ) if @email_id.present?
     end
+
+    alias_method :deliver_now, :deliver
+
+    # Invoke <tt>SendWithUs::Api</tt> to deliver the message later via ActiveJob.
+    # The <tt>SendWithUs</tt> module is implemented in the +send_with_us+ gem.
+    #
+    # IMPORTANT NOTE: <tt>SendWithUs</tt> must be configured prior to calling this method.
+    # In particular, the +api_key+ must be set (following the guidelines in the
+    # +send_with_us+ documentation).
+    def deliver_later
+      Jobs::MailJob.perform_later(
+          @email_id,
+          @to,
+          data: @email_data,
+          from: @from,
+          cc: @cc,
+          bcc: @bcc,
+          esp_account: @esp_account,
+          version_name: @version_name,
+          locale: @locale,
+          files: @files,
+          headers: @headers,
+          tags: @tags
+      ) if @email_id.present?
+    end
   end
 end

--- a/sendwithus_ruby_action_mailer.gemspec
+++ b/sendwithus_ruby_action_mailer.gemspec
@@ -21,7 +21,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_runtime_dependency 'send_with_us', '>= 1.9.0'
-  gem.add_development_dependency 'actionpack'
+  gem.add_runtime_dependency 'actionpack'
+  gem.add_runtime_dependency 'activejob'
+
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest-colorize'
   gem.add_development_dependency 'mocha'

--- a/test/lib/sendwithus_ruby_action_mailer/mail_params_test.rb
+++ b/test/lib/sendwithus_ruby_action_mailer/mail_params_test.rb
@@ -1,6 +1,8 @@
 require_relative '../../test_helper'
 
 describe SendWithUsMailer::MailParams do
+  include ActiveJob::TestHelper
+
   subject { SendWithUsMailer::MailParams.new }
 
   describe "initialization" do
@@ -63,9 +65,45 @@ describe SendWithUsMailer::MailParams do
       subject.deliver
     end
 
-    it "doesnt call the send_with_us gem if mail method is not called" do
+    it "doesn't call the send_with_us gem if mail method is not called" do
       SendWithUs::Api.any_instance.expects(:send_with).never
       subject.deliver
+    end
+  end
+
+  describe "#deliver_now" do
+    it "method exists" do
+      subject.respond_to?(:deliver_now).must_equal true
+    end
+
+    it "calls the send_with_us gem" do
+      subject.merge!(email_id: 'x')
+      SendWithUs::Api.any_instance.expects(:send_email)
+      subject.deliver_now
+    end
+
+    it "doesn't call the send_with_us gem if mail method is not called" do
+      SendWithUs::Api.any_instance.expects(:send_with).never
+      subject.deliver_now
+    end
+  end
+
+  describe "#deliver_later" do
+    it "method exists" do
+      subject.respond_to?(:deliver_later).must_equal true
+    end
+
+    it "enqueues the job" do
+      subject.merge!(email_id: 'x')
+      assert_enqueued_with(job: SendWithUsMailer::Jobs::MailJob) do
+        subject.deliver_later
+      end
+    end
+
+    it "doesn't call the send_with_us gem if no email_id" do
+      assert_no_enqueued_jobs do
+        subject.deliver_later
+      end
     end
   end
 end


### PR DESCRIPTION
Add code to use active_job to queue an SWE mail job

Add tests to exercise deliver_later for a mail job

Properly scope class definition and update dependent tests.

Move modules to be runtime dependencies

Alias #deliver to #deliver_now to match ActionMailer's signature.

Make job match ActionMailer more closely by using the same mail queue name and naming arguments more explicitly.

Tighten scope to reference related submodule

Fix error in mail queue name

Reorder dependencies in gemspec into logical groupings.
