### PR TITLE
Add support for ActionMailer semantics 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/version_tmp
 tmp
 *.tmproj
 .rvmrc
+.idea

--- a/lib/sendwithus_ruby_action_mailer/mail_params.rb
+++ b/lib/sendwithus_ruby_action_mailer/mail_params.rb
@@ -88,8 +88,12 @@ module SendWithUsMailer
     # IMPORTANT NOTE: <tt>SendWithUs</tt> must be configured prior to calling this method.
     # In particular, the +api_key+ must be set (following the guidelines in the
     # +send_with_us+ documentation).
-    def deliver_later
-      Jobs::MailJob.perform_later(
+    def deliver_later(options = {})
+      job = Jobs::MailJob.set(queue: options[:queue],
+                              wait: options[:wait],
+                              wait_until: options[:wait_until])
+
+      job.perform_later(
           @email_id,
           @to,
           data: @email_data,


### PR DESCRIPTION
Allow clients to `:wait` a certain amount of time, 
`:wait_until` a certain date/time, 
and choose a `:queue` on which to enqueue the job.