### PR TITLE
Add support for MailJob options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ class Notifier < SendWithUsMailer::Base
         assign(:captain_name, recipient.name)
         #=> in sendwithus email template {{ captain_name }}
         assign :team, {team_name: recipient.team_name, captain: recipient.name}
-        #=> in sendwithus email template {{ team.team_name }} and {{ team.captain }} 
+        #=> in sendwithus email template {{ team.team_name }} and {{ team.captain }}
 
         mail(
             email_id: 'ID-CODE-FROM-SEND-WITH-US',
@@ -100,6 +100,12 @@ Notifier.welcome(nick).deliver_later # sends the email asynchronously
 
 mail = Notifier.welcome(david)  # => a SendWithUsMailer::MailParams object
 mail.deliver_later              # sends the email asynchronously
+
+mail = Notifier.welcome(david)  # => a SendWithUsMailer::MailParams object
+mail.deliver_later(             # send the email asynchronously in
+  wait: 5.minutes,              # 5 minutes via the mailers queue
+  queue: :priority
+)
 `````
 
 You never instantiate your mailer class. Rather, you just call the method you defined

--- a/lib/sendwithus_ruby_action_mailer/mail_params.rb
+++ b/lib/sendwithus_ruby_action_mailer/mail_params.rb
@@ -88,8 +88,8 @@ module SendWithUsMailer
     # IMPORTANT NOTE: <tt>SendWithUs</tt> must be configured prior to calling this method.
     # In particular, the +api_key+ must be set (following the guidelines in the
     # +send_with_us+ documentation).
-    def deliver_later
-      Jobs::MailJob.perform_later(
+    def deliver_later(options = {})
+      Jobs::MailJob.set(options).perform_later(
           @email_id,
           @to,
           data: @email_data,

--- a/test/lib/sendwithus_ruby_action_mailer/mail_params_test.rb
+++ b/test/lib/sendwithus_ruby_action_mailer/mail_params_test.rb
@@ -100,6 +100,13 @@ describe SendWithUsMailer::MailParams do
       end
     end
 
+    it "enqueues the job with options" do
+      subject.merge!(email_id: 'x')
+      assert_enqueued_with(job: SendWithUsMailer::Jobs::MailJob, at: 3.minutes.from_now) do
+        subject.deliver_later(wait: 3.minutes)
+      end
+    end
+
     it "doesn't call the send_with_us gem if no email_id" do
       assert_no_enqueued_jobs do
         subject.deliver_later


### PR DESCRIPTION
Add support for MailJob options

## Motivation and Context

`deliver_later` should be compatible with ActionMailer `deliver_later`

## How Has This Been Tested?

With a spec

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.